### PR TITLE
Float to string conversion using sprintf

### DIFF
--- a/src/UbidotsCC3200.cpp
+++ b/src/UbidotsCC3200.cpp
@@ -226,8 +226,12 @@ bool Ubidots::sendAll() {
   sprintf(body, "{");
   for (i = 0; i < _currentValue;) {
     _value = (val+i)->varValue; // float variable value
+    
     /* Saves variable value in str */
-    dtostrf(_value, 4, 3, str_val); // String variable value
+    //dtostrf(_value, 4, 3, str_val); // String variable value
+    int _ivalue = (int)_value;
+    sprintf(str_val, "%d.%d", _ivalue, (int)((_value -_ivalue)*1000)); // Precision of 3 decimal places
+    
     sprintf(body, "%s\"%s\":", body, (val + i)->varLabel);
     if ((val + i)->context != '\0') {
       sprintf(body, "%s{\"value\":%s, \"context\":{%s}}", body, str_val, (val + i)->context );


### PR DESCRIPTION
I was experiencing problems with the library, namely due to an incorrect HTTP request (or incomplete 
JSON data).

What I found out was that the dtostrf() function wasn't working i.e. no conversion took place and str_val 
was essentially an empty char array. The board I have used was a Tiva C TM4C123GXL with a CC3100 booster pack and my environment was Energia IDE 1.8.7E21.

One way I used to circumvent around this, was to use the standard sprintf() function with the %d 
format specifier as in the modified source code.